### PR TITLE
Possible fix for get_build_via_exporttool() crashing upon attempting to index possible_versions variable

### DIFF
--- a/ms-exchange-version.nse
+++ b/ms-exchange-version.nse
@@ -70,6 +70,9 @@ local function get_build_via_exporttool(host, port, build, build_version_map)
 
     -- brute force for the exporttool path
     local possible_versions = build_version_map[build]
+    if (possible_versions == nil) then
+    	return build
+    end
     if (version == nil and build ~= nil) then
         for _, v in ipairs(possible_versions) do
             http.get(host.targetname or host.ip, port, ("/ecp/%s/exporttool/microsoft.exchange.ediscovery.exporttool.application"):format(v.build), http_options)


### PR DESCRIPTION
Upon using this to scan IPs, the get_build_via_exporttool() consistently crashed for me as it attempts to index a nil value in possible_versions.

```
attempt to index a nil value
stack traceback:
	[C]: in for iterator 'for iterator'
	ms-exchange-version.nse:74: in upvalue 'get_build_via_exporttool'
	ms-exchange-version.nse:103: in upvalue 'get_owa_build'
	ms-exchange-version.nse:215: in function <ms-exchange-version.nse:211>
	(...tail calls...)
```
This is solved by checking whether possible_versions is nil and returning build if this is the case. It now runs smoothly for me.